### PR TITLE
Fix rouille impl bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-sig"
 description = "Implementation of the IETF draft 'Signing HTTP Messages'"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jack Cargill <jack@passfort.com>", "Diggory Blake"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ features.
 | [reqwest](https://crates.io/crates/reqwest)       | Client        | Supports blocking and non-blocking requests.<sup>1</sup>      |
 | [rouille](https://crates.io/crates/rouille)       | Server        |                                                               |
 
-1. Due to limitations of the reqwest API, digests can only be calculated automatically for non-blocking non-streaming requests. For
-   blocking or streaming requests, the user must add the digest manually before signing the request, or else the `Digest` header will
-   not be included in the signature.
+1. Due to limitations of the reqwest API, digests cannot be calculated automatically for non-blocking, streaming requests. For
+   these requests, the user must add the digest manually before signing the request, or else the `Digest` header will
+   not be included in the signature. Automatic digests for streaming requests *are* supported via the blocking API.
 
 ### Supported signature algorithms:
 
 Algorithm registry: https://tools.ietf.org/id/draft-cavage-http-signatures-12.html#hsa-registry
 
 - `hmac-sha256`
+- `hmac-sha512`
+- `rsa-sha256`
+- `rsa-sha512`
 
 ### Supported digest algorithms:
 


### PR DESCRIPTION
Rouille returns `Some(empty body)` for GET requests, rather than the `None` we
were expecting, so allow the digest to be omitted when the body is present but
empty.