### PR TITLE
Bump sha2 and hmac crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ members = ["http-sig-validator"]
 [dependencies]
 chrono = "0.4.11"
 http = "0.2.1"
-sha2 = "0.8.1"
+sha2 = "0.10.1"
 base64 = "0.12.0"
 reqwest = {version = "0.11", features = ["blocking"], optional = true}
 rouille = {version = "3.0.0", optional = true}
 subtle = "2.2.2"
 ring = { version = "0.16.12", features = ["std"], optional = true }
 url = "2.1.1"
-hmac = "0.7.1"
+hmac = "0.12"
 openssl = { version = "0.10.29", optional = true }
 log = "0.4.8"
 anyhow = "1.0.28"

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -46,16 +46,16 @@ macro_rules! hmac_signature {
             /// Create a new instance of the signature scheme using the
             /// provided key.
             pub fn new(key: &[u8]) -> Self {
-                Self(Hmac::new_varkey(key).expect("Hmac construction should be infallible"))
+                Self(Hmac::new_from_slice(key).expect("Hmac construction should be infallible"))
             }
         }
 
         impl HttpSignatureSign for $typename {
             fn http_sign(&self, bytes_to_sign: &[u8]) -> String {
                 let mut hmac = self.0.clone();
-                hmac.input(bytes_to_sign);
-                let tag = hmac.result().code();
-                base64::encode(tag.as_ref())
+                hmac.update(bytes_to_sign);
+                let tag = hmac.finalize().into_bytes();
+                base64::encode(tag)
             }
         }
         impl HttpSignatureVerify for $typename {
@@ -65,8 +65,8 @@ macro_rules! hmac_signature {
                     Err(_) => return false,
                 };
                 let mut hmac = self.0.clone();
-                hmac.input(bytes_to_verify);
-                hmac.verify(&tag).is_ok()
+                hmac.update(bytes_to_verify);
+                hmac.verify_slice(&tag).is_ok()
             }
         }
     };


### PR DESCRIPTION
Dependency name change triggerd RUSTSEC-2021-0064

https://rustsec.org/advisories/RUSTSEC-2021-0064