### PR TITLE
Populates the `algorithm` Signature Parameter based on which Signer is used.

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -10,6 +10,10 @@ pub trait HttpSignatureSign: Debug + Send + Sync + 'static {
     /// header. For all currently supported signature schemes, the encoding is
     /// specified to be base64.
     fn http_sign(&self, bytes_to_sign: &[u8]) -> String;
+
+    /// Returns the name of this signing algorithm, as expected by the algorithm
+    /// parameter in the HTTP Authorization header.
+    fn name(&self) -> &str;
 }
 
 /// Implements the verification half of an HTTP signature algorithm. For symmetric
@@ -56,6 +60,10 @@ macro_rules! hmac_signature {
                 hmac.update(bytes_to_sign);
                 let tag = hmac.finalize().into_bytes();
                 base64::encode(tag)
+            }
+
+            fn name(&self) -> &str {
+                $name
             }
         }
         impl HttpSignatureVerify for $typename {

--- a/src/algorithm/openssl.rs
+++ b/src/algorithm/openssl.rs
@@ -76,6 +76,12 @@ macro_rules! rsa_signature {
                     .expect("Signing to be infallible");
                 base64::encode(&tag)
             }
+
+            
+            fn name(&self) -> &str {
+                $name
+            }
+            
         }
         impl HttpSignatureVerify for $verify_name {
             fn http_verify(&self, bytes_to_verify: &[u8], signature: &str) -> bool {

--- a/src/algorithm/ring.rs
+++ b/src/algorithm/ring.rs
@@ -60,6 +60,10 @@ macro_rules! rsa_signature {
                     .expect("Signing should be infallible");
                 base64::encode(&tag)
             }
+
+            fn name(&self) -> &str {
+                $name
+            }
         }
         impl HttpSignatureVerify for $verify_name {
             fn http_verify(&self, bytes_to_verify: &[u8], signature: &str) -> bool {

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -474,10 +474,13 @@ impl<R: ClientRequestLike> SigningExt for R {
         // Sign the content
         let signature = config.signature.http_sign(content.as_bytes());
 
+        // Get the algorithm name
+        let sig_algo = config.signature.name();
+
         // Construct the authorization header
         let auth_header = format!(
-            r#"Signature keyId="{}",algorithm="{}",signature="{}",headers="{}"#,
-            config.key_id, "hs2019", signature, joined_headers
+            r#"Signature keyId="{}",algorithm="{}",signature="{}",headers="{}""#,
+            config.key_id, sig_algo, signature, joined_headers
         );
 
         // Attach the authorization header to the request


### PR DESCRIPTION
Currently the code uses a hardcoded value for the default signer, which means that attempting to use `RsaSha256Sign` as a signer produces an invalid authorization header. This PR attempts to fix that by adding a `name` method to `HttpSignatureSign` and implementing it with the name literal string passed to the macros. This is the correct value for rsa-sha signing, but may not be correct for hmac. I'm happy to make changes as necessary.