### PR TITLE
headers: use Signature header as specified in draft-12

### DIFF
--- a/src/canonicalize.rs
+++ b/src/canonicalize.rs
@@ -20,7 +20,7 @@ pub enum CanonicalizeError {
 pub trait RequestLike {
     /// Returns an existing header on the request. This method *must* reflect changes made
     /// be the `ClientRequestLike::set_header` method, with the possible exception of the
-    /// `Authorization` header itself.
+    /// `Signature` header itself.
     fn header(&self, header: &Header) -> Option<HeaderValue>;
 
     /// Returns true if this request contains a value for the specified header. If this

--- a/src/mock_request.rs
+++ b/src/mock_request.rs
@@ -253,9 +253,8 @@ mod tests {
     fn default_test() {
         // Expect successful validation
         let mut req = test_request().with_header(
-            "Authorization",
+            "Signature",
             "\
-            Signature \
                 keyId=\"Test\", \
                 algorithm=\"rsa-sha256\", \
                 headers=\"date\", \
@@ -285,9 +284,8 @@ mod tests {
     fn basic_test() {
         // Expect successful validation
         let req = test_request().with_header(
-            "Authorization",
+            "Signature",
             "\
-            Signature \
                 keyId=\"Test\", \
                 algorithm=\"rsa-sha256\", \
                 headers=\"(request-target) host date\", \
@@ -313,9 +311,8 @@ mod tests {
     fn all_headers_test() {
         // Expect successful validation
         let req = test_request().with_header(
-            "Authorization",
+            "Signature",
             "\
-            Signature \
                 keyId=\"Test\", \
                 algorithm=\"rsa-sha256\", \
                 created=1402170695, \

--- a/src/reqwest_impls.rs
+++ b/src/reqwest_impls.rs
@@ -66,7 +66,7 @@ impl ClientRequestLike for reqwest::blocking::Request {
 #[cfg(test)]
 mod tests {
     use chrono::{offset::TimeZone, Utc};
-    use http::header::{AUTHORIZATION, CONTENT_TYPE, DATE};
+    use http::header::{CONTENT_TYPE, DATE};
 
     use super::*;
 
@@ -92,7 +92,7 @@ mod tests {
 
         let with_sig = without_sig.signed(&config).unwrap();
 
-        assert_eq!(with_sig.headers().get(AUTHORIZATION).unwrap(), "Signature keyId=\"test_key\",algorithm=\"hs2019\",signature=\"F8gZiriO7dtKFiP5eSZ+Oh1h61JIrAR6D5Mdh98DjqA=\",headers=\"(request-target) host date digest");
+        assert_eq!(with_sig.headers().get("Signature").unwrap(), "keyId=\"test_key\",algorithm=\"hs2019\",signature=\"F8gZiriO7dtKFiP5eSZ+Oh1h61JIrAR6D5Mdh98DjqA=\",headers=\"(request-target) host date digest\"");
         assert_eq!(
             with_sig
                 .headers()

--- a/src/rouille_impls.rs
+++ b/src/rouille_impls.rs
@@ -108,7 +108,7 @@ mod tests {
                     .format("%a, %d %b %Y %T GMT")
                     .to_string()),
                 ("Digest".into(), "SHA-256=2vgEVkfe4d6VW+tSWAziO7BUx7uT/rA9hn1EoxUJi2o=".into()),
-                ("Authorization".into(), "Signature keyId=\"test_key\",algorithm=\"hmac-sha256\",signature=\"uH2I9FSuCGUrIEygs7hR29oz0Afkz0bZyHpz6cW/mLQ=\",headers=\"(request-target) date digest host".into()),
+                ("Signature".into(), "keyId=\"test_key\",algorithm=\"hmac-sha256\",signature=\"uH2I9FSuCGUrIEygs7hR29oz0Afkz0bZyHpz6cW/mLQ=\",headers=\"(request-target) date digest host\"".into()),
             ],
             br#"{ "x": 1, "y": 2}"#[..].into()
         );
@@ -133,7 +133,7 @@ mod tests {
                     .and_hms(9, 10, 11)
                     .format("%a, %d %b %Y %T GMT")
                     .to_string()),
-                ("Authorization".into(), "Signature keyId=\"test_key\",algorithm=\"hmac-sha256\",signature=\"sGQ3hA9KB40CU1pHbRLXLvLdUWYn+c3fcfL+Sw8kIZE=\",headers=\"(request-target) date".into()),
+                ("Signature".into(), "keyId=\"test_key\",algorithm=\"hmac-sha256\",signature=\"sGQ3hA9KB40CU1pHbRLXLvLdUWYn+c3fcfL+Sw8kIZE=\",headers=\"(request-target) date\"".into()),
             ],
             Vec::new()
         );

--- a/src/verifying.rs
+++ b/src/verifying.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use http::header::{HeaderName, HeaderValue, AUTHORIZATION, DATE};
+use http::header::{HeaderName, HeaderValue, DATE};
 use sha2::{Digest, Sha256, Sha512};
 use subtle::ConstantTimeEq;
 
@@ -349,25 +349,26 @@ fn verify_signature_only<T: ServerRequestLike>(
     req: &T,
     config: &VerifyingConfig,
 ) -> Option<(BTreeMap<Header, HeaderValue>, VerificationDetails)> {
-    let auth_header = req.header(&AUTHORIZATION.into()).or_else(|| {
-        info!("Verification Failed: No 'Authorization' header");
+    // TODO : Signature
+    let auth_header = req.header(&http::header::AUTHORIZATION.into()).or_else(|| {
+        info!("Verification Failed: No 'Signature' header");
         None
     })?;
     let mut auth_header = auth_header
         .to_str()
         .ok()
         .or_else(|| {
-            info!("Verification Failed: Non-ascii 'Authorization' header");
+            info!("Verification Failed: Non-ascii 'Signature' header");
             None
         })?
         .splitn(2, ' ');
 
     let auth_scheme = auth_header.next().or_else(|| {
-        info!("Verification Failed: Malformed 'Authorization' header");
+        info!("Verification Failed: Malformed 'Signature' header");
         None
     })?;
     let auth_args = auth_header.next().or_else(|| {
-        info!("Verification Failed: Malformed 'Authorization' header");
+        info!("Verification Failed: Malformed 'Signature' header");
         None
     })?;
 
@@ -388,16 +389,16 @@ fn verify_signature_only<T: ServerRequestLike>(
         })
         .collect::<Option<BTreeMap<_, _>>>()
         .or_else(|| {
-            info!("Verification Failed: Unable to parse 'Authorization' header");
+            info!("Verification Failed: Unable to parse 'Signature' header");
             None
         })?;
 
     let key_id = *auth_args.get("keyId").or_else(|| {
-        info!("Verification Failed: Missing required 'keyId' in 'Authorization' header");
+        info!("Verification Failed: Missing required 'keyId' in 'Signature' header");
         None
     })?;
     let provided_signature = auth_args.get("signature").or_else(|| {
-        info!("Verification Failed: Missing required 'signature' in 'Authorization' header");
+        info!("Verification Failed: Missing required 'signature' in 'Signature' header");
         None
     })?;
     let algorithm_name = auth_args.get("algorithm").copied();


### PR DESCRIPTION
I don't know if I will finish (I didn't play with the verification yet nor rouille), but draft got updated and "Signature" is the header used.

Moreover, while testing this library against a mastodon instance I saw that a quote was missing at the end of the Signature line (after `headers="(request-target) date digest host`) causing the header to be rejected.

So, if anyone want to use this for playing with a mastodon instance, I guess you will need a similar patch.

Merry Xmas and have fun.